### PR TITLE
Update encodingdb.py

### DIFF
--- a/pdfminer/encodingdb.py
+++ b/pdfminer/encodingdb.py
@@ -59,7 +59,7 @@ class EncodingDB(object):
                 elif isinstance(x, PSLiteral):
                     try:
                         cid2unicode[cid] = name2unicode(x.name)
-                    except KeyError:
+                    except (KeyError, OverflowError):
                         pass
                     cid += 1
         return cid2unicode

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -113,7 +113,7 @@ class Type1FontHeaderParser(PSStackParser):
                 break
             try:
                 self._cid2unicode[cid] = name2unicode(name)
-            except KeyError:
+            except (KeyError, OverflowError):
                 pass
         return self._cid2unicode
 


### PR DESCRIPTION
Fix for custom font encoding overflow caused by `226215240241240240240240`.

Proposed in https://github.com/euske/pdfminer/pull/150